### PR TITLE
feat: renew certificates on the instance with certbot

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,4 @@
 ---
-skip_list:
-  - name[casing]
 exclude_paths:
+  - .ansible
   - .github

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ansible/
+.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 2.0.0 (2026-08-18)
+
+The role no longer implements the ACME protocol with Ansible modules. It now installs and
+configures certbot on the target host, which means **the certificate renews itself**
+instead of only being renewed when a playbook happens to run.
+
+### Breaking changes:
+
+- Certificates are issued by `certbot`, installed from the distribution repositories
+  along with `python3-certbot-dns-cloudflare`. The host must be Debian or Ubuntu with
+  systemd.
+- The Cloudflare API token is now stored on the host at `/etc/letsencrypt/cloudflare.ini`
+  (`0600 root:root`). This is unavoidable for unattended DNS-01 renewal; scope the token
+  to a single zone, or delegate `_acme-challenge` by CNAME to a throwaway zone.
+- Output moved to `/etc/letsencrypt/live/<ssl_cert_name>/`, keeping the names
+  `privkey.pem`, `cert.pem`, `chain.pem` and `fullchain.pem`. Certificates issued by 1.x
+  are not adopted; a fresh one is issued on first run.
+- Default key type is now `ecdsa`, following certbot's own default. Set
+  `ssl_key_type: rsa` with `ssl_rsa_key_size` for the previous behaviour.
+- Variables reworked:
+
+  | 1.x | 2.0 |
+  | - | - |
+  | `ssl_cloudflare_domain` (string) | `ssl_domains` (list of names, no `DNS:` prefix), plus `ssl_cert_name` for the lineage name |
+  | `ssl_san_certificates` | folded into `ssl_domains` |
+  | `ssl_letsencrypt_email` | `ssl_email` |
+  | `ssl_cert_directory`, `ssl_key_directory` | `ssl_dir`, plus `ssl_privatekey`, `ssl_cert`, `ssl_fullchain`, `ssl_chain` |
+  | `ssl_cloudflare_token` | unchanged |
+
+- `min_ansible_version` raised from 2.17 to 2.18.
+
+### Features:
+
+- Unattended renewal on the instance via `certbot.timer`, enabled by default and
+  controlled with `ssl_auto_renew`. No scheduled Ansible run needed.
+- `ssl_reload_services` and `ssl_deploy_hook_command` install a deploy hook that runs
+  after every successful renewal.
+- `ssl_renew_days` moves the renewal window; empty keeps certbot's default.
+- `ssl_acme_directory` makes the endpoint configurable, so the role can be tested against
+  Let's Encrypt staging instead of burning production rate limits.
+- Changing `ssl_domains` reissues the certificate instead of being silently ignored.
+
+### Fixes:
+
+The following bugs were all in the hand-rolled DNS-01 handling, which no longer exists:
+
+- Challenge TXT records were published with `solo: true`. The apex and the wildcard share
+  the `_acme-challenge.<zone>` record name, so publishing the second value deleted the
+  first one and validation failed.
+- The challenge was read from `challenge_data`, which yields one entry per identifier and
+  therefore duplicate record names, instead of `challenge_data_dns`.
+- Validation was requested with no wait for DNS propagation. The `until`/`retries` in
+  place only retried when the module itself errored, which does not recover an
+  authorization already burned by a failed validation.
+- The ACME account was handled implicitly, with two different contact addresses for the
+  same account key. That behaviour is deprecated and removed in `community.crypto` 4.0.0.
+
+### Other changes:
+
+- The `community.crypto` and `community.general` collections are no longer required; the
+  role is pure `ansible.builtin`.
+- `requirements-ansible.txt` installs `ansible-core` instead of the full `ansible`
+  package.
+- README no longer claims the role encrypts anything with Ansible Vault; it never did.
+
 ## 1.0.0 (2024-09-20)
 
 ### Features:

--- a/README.md
+++ b/README.md
@@ -1,33 +1,76 @@
 # Ansible Role: Let's Encrypt SSL Certificate with Cloudflare DNS Verification
 
-This Ansible role automates the process of generating SSL certificates using [Let's Encrypt](https://letsencrypt.org/) with DNS verification, managed via [Cloudflare](https://www.cloudflare.com/) DNS.
+This Ansible role installs and configures [certbot](https://certbot.eff.org/) so a host
+issues its own TLS certificate from an ACME CA ([Let's Encrypt](https://letsencrypt.org/)
+by default) and **renews it unattended**, solving the DNS-01 challenge through
+[Cloudflare](https://www.cloudflare.com/) DNS.
+
+Renewal is handled on the instance by certbot's own systemd timer, which runs twice a
+day. Ansible is only needed for the initial setup: once the role has run, the host keeps
+its certificate valid on its own.
+
+Because the challenge is solved over DNS, a single certificate can cover the apex and
+every subdomain (`*.example.com`), and it is reusable by any service rather than locked
+inside one reverse proxy.
 
 ## Features
 
-- Generates a private key and Certificate Signing Request (CSR).
-- Uses the DNS challenge to verify domain ownership with Cloudflare DNS.
-- Obtains SSL certificates from Let's Encrypt.
-- Supports automatic certificate renewal.
-- Encrypts the generated keys and certificates using Ansible Vault.
-- Cleans up the DNS challenge record after verification.
+- Installs `certbot` and the Cloudflare DNS plugin from the distribution repositories.
+- Issues a certificate covering every name in `ssl_domains`, wildcards included.
+- Leaves renewal to `certbot.timer` - no scheduled Ansible run required.
+- Optionally reloads services after each successful renewal via a deploy hook.
+- Re-running the role is a no-op unless the domain list changed or the certificate is
+  due for renewal.
 
 ## Requirements
 
-- Ansible 2.17.4 or higher.
-- Cloudflare account with API token access.
+- `ansible-core` 2.18 or higher. No external collections.
+- A Debian or Ubuntu host with systemd. `certbot` and `python3-certbot-dns-cloudflare`
+  come from the distribution repositories (Debian bookworm ships certbot 2.0, trixie 4.0).
+- A Cloudflare API token with permission to edit DNS in the zone holding the challenge
+  records - the "Edit zone DNS" template (`Zone:DNS:Edit` + `Zone:Read`) scoped to that
+  zone. Keep it out of plain text, for example with `ansible-vault encrypt_string`.
+
+### About the token on the host
+
+Unattended DNS-01 renewal requires the token to live on the instance, at
+`{{ ssl_credentials_file }}` (`0600 root:root`). This is inherent to renewing without a
+human or a control node present, not specific to certbot. To limit the blast radius:
+
+- Scope the token to the single zone it needs, never an account-wide key.
+- Or delegate validation: `CNAME _acme-challenge.example.com` to a record in a throwaway
+  zone, and issue a token that can only edit that zone. A compromised host then cannot
+  touch your real DNS records.
 
 ## Role Variables
 
-Here are the role variables and their default values. You will need to override them in your playbook or inventory to suit your environment:
+### Required
+
+| Variable | Description |
+| - | - |
+| `ssl_domains` | List of domain names for the certificate, apex first, e.g. `["example.com", "*.example.com"]`. |
+| `ssl_cloudflare_token` | Cloudflare API token with permission to manage DNS records in the zone. |
+
+### Optional
 
 | Variable | Description | Default |
 | - | - | - |
-| ssl_cloudflare_domain | The domain name for which the SSL certificate will be generated. | - |
-| ssl_cloudflare_token | Cloudflare API token with permissions to manage DNS records. | - |
-| ssl_letsencrypt_email | Email address used to notify you when the certificate is approaching its expiration date. | `admin@{{ ssl_cloudflare_domain }}` |
-| ssl_san_certificates | Subject Alternative Name(s) for the certificate. | `'["DNS:www.{{ ssl_cloudflare_domain }}"]'` |
-| ssl_cert_directory | Directory where SSL certificates will be stored. | `/etc/ssl/certs` |
-| ssl_key_directory | Directory where SSL private keys will be stored. | `/etc/ssl/private` |
+| `ssl_cert_name` | Certbot lineage name; decides the output directory. | First entry of `ssl_domains`, with a leading `*.` stripped |
+| `ssl_email` | Address notified when the certificate approaches expiry. | `admin@{{ ssl_cert_name }}` |
+| `ssl_acme_directory` | ACME endpoint. Point it at staging while testing. | `https://acme-v02.api.letsencrypt.org/directory` |
+| `ssl_key_type` | `ecdsa` or `rsa`. | `ecdsa` |
+| `ssl_rsa_key_size` | Key size, only used when `ssl_key_type` is `rsa`. | `4096` |
+| `ssl_dns_propagation_seconds` | Seconds to wait for the TXT records to propagate before validation. | `30` |
+| `ssl_credentials_file` | Where the Cloudflare token is stored on the host. | `/etc/letsencrypt/cloudflare.ini` |
+| `ssl_auto_renew` | Enable and start `certbot.timer`. | `true` |
+| `ssl_renew_days` | Renew when fewer than this many days remain. Empty keeps certbot's default (a third of the lifetime). | `""` |
+| `ssl_reload_services` | Units to `systemctl reload` after a successful renewal. | `[]` |
+| `ssl_deploy_hook_command` | Extra command to run after a successful renewal. | `""` |
+| `ssl_dir` | Directory holding the issued material. | `/etc/letsencrypt/live/{{ ssl_cert_name }}` |
+| `ssl_privatekey`, `ssl_cert`, `ssl_chain`, `ssl_fullchain` | Individual output paths. | see below |
+
+Set `ssl_cert_name` explicitly if the derived default is not what you want; changing it
+later moves the output directory, so pick it once.
 
 ## Example Playbook
 
@@ -37,20 +80,67 @@ Here are the role variables and their default values. You will need to override 
   roles:
     - role: dsegurag.ssl
       vars:
-        ssl_cloudflare_domain: "example.com"
+        ssl_domains:
+          - example.com
+          - "*.example.com"
         ssl_cloudflare_token: "{{ lookup('ansible.builtin.env', 'CLOUDFLARE_API_TOKEN') }}"
-        ssl_letsencrypt_email: "admin@{{ ssl_cloudflare_domain }}"
-        ssl_san_certificates: '["DNS:*.{{ ssl_cloudflare_domain }}"]'
+        ssl_email: admin@example.com
+        ssl_reload_services:
+          - nginx
 ```
 
-## Tasks Overview
+## Issuing and renewal
 
-1. Create Directories: Generates directories for decrypted and encrypted SSL files with appropriate permissions.
-2. Generate Private Key and CSR: Creates a 4096-bit RSA private key and generates a CSR for the specified domain.
-3. Create Let’s Encrypt Account Key: Generates a separate private key for Let's Encrypt interactions.
-4. Create DNS Challenge Record: Creates a DNS TXT record for the DNS challenge via Cloudflare.
-5. Validate and Retrieve Certificate: Waits for the challenge to be validated and retrieves the certificate, intermediate chain, and full chain.
-6. Clean Up: Deletes the DNS TXT record for the challenge once verification is complete.
+Test against the staging endpoint first:
+
+```yaml
+ssl_acme_directory: https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+Let's Encrypt limits you to 5 duplicate certificates per week and a failed run still
+counts, so staging is worth the extra round. Staging certificates are not trusted by
+browsers; remove `/etc/letsencrypt` before the first production run.
+
+Verify unattended renewal once, on the host:
+
+```bash
+systemctl list-timers certbot.timer   # active, with a next trigger
+certbot renew --dry-run               # full renewal cycle against the CA's staging
+```
+
+Re-running the role is a no-op while the certificate covers the same domains and is not
+due for renewal. Adding or removing a name in `ssl_domains` does trigger a reissue.
+
+## Output files
+
+`/etc/letsencrypt/live/<ssl_cert_name>/`:
+
+| File | Contents |
+| - | - |
+| `privkey.pem` | Certificate private key |
+| `cert.pem` | Certificate |
+| `chain.pem` | Intermediate certificates |
+| `fullchain.pem` | Certificate plus intermediates - what most servers want |
+
+Reference `ssl_fullchain` and `ssl_privatekey` rather than hardcoding these paths.
+
+These are symlinks into `/etc/letsencrypt/archive/`, which matters for containers: bind
+mount `/etc/letsencrypt` as a whole, not just `live/`, or the symlinks will dangle.
+
+## Upgrading from 1.x
+
+Version 2.0.0 replaces the in-Ansible ACME client with certbot, so the host renews on its
+own. See the [CHANGELOG](CHANGELOG.md) for the full mapping; in short:
+
+| 1.x | 2.0 |
+| - | - |
+| `ssl_cloudflare_domain` | `ssl_domains` (list), and `ssl_cert_name` if you want a different lineage name |
+| `ssl_san_certificates` | folded into `ssl_domains`, without the `DNS:` prefix |
+| `ssl_letsencrypt_email` | `ssl_email` |
+| `ssl_cert_directory`, `ssl_key_directory` | `ssl_dir` and the per-file variables above |
+
+Output moved to `/etc/letsencrypt/live/<name>/`. Certificates issued by 1.x are not
+adopted; the role issues a fresh one on first run.
 
 ## Dependencies
 

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "1.0.1"
+current_version = "2.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,51 @@
 ---
-ssl_letsencrypt_email: "admin@{{ ssl_cloudflare_domain }}"
-ssl_san_certificates:
-  - "DNS:www.{{ ssl_cloudflare_domain }}"
+# Certbot lineage name. It decides the output path, /etc/letsencrypt/live/<name>/,
+# so pin it explicitly: left to itself certbot derives the name from the first
+# domain and appends -0001 as soon as the domain set changes, which would move
+# the files out from under whatever is serving them.
+ssl_cert_name: "{{ ssl_domains | first | regex_replace('^\\*\\.', '') }}"
 
-ssl_cert_directory: /etc/ssl/certs
-ssl_key_directory: /etc/ssl/private
+# Account e-mail for expiry notices.
+ssl_email: "admin@{{ ssl_cert_name }}"
+
+# ACME endpoint. Defaults to Let's Encrypt production; override with the staging
+# directory (https://acme-staging-v02.api.letsencrypt.org/directory) while
+# testing to avoid the duplicate-certificate rate limit.
+ssl_acme_directory: https://acme-v02.api.letsencrypt.org/directory
+
+# Certificate key. ecdsa is certbot's own default since 2.0; switch to rsa if you
+# need to support clients that predate widespread ECDSA support.
+ssl_key_type: ecdsa
+ssl_rsa_key_size: 4096
+
+# Seconds certbot waits for the _acme-challenge TXT records to reach Cloudflare's
+# authoritative name servers before asking the CA to validate them.
+ssl_dns_propagation_seconds: 30
+
+# Cloudflare API token, read by the certbot plugin. Must stay on the host for
+# unattended renewal to work.
+ssl_credentials_file: /etc/letsencrypt/cloudflare.ini
+
+# Where certbot writes the issued material. Reference these variables rather than
+# hardcoding paths.
+ssl_dir: "/etc/letsencrypt/live/{{ ssl_cert_name }}"
+ssl_privatekey: "{{ ssl_dir }}/privkey.pem"
+ssl_cert: "{{ ssl_dir }}/cert.pem"
+ssl_chain: "{{ ssl_dir }}/chain.pem"
+ssl_fullchain: "{{ ssl_dir }}/fullchain.pem"
+
+# Unattended renewal, handled on the instance by certbot.timer.
+ssl_auto_renew: true
+
+# Renew when fewer than this many days of validity remain. Empty keeps certbot's
+# own default, which renews once less than a third of the lifetime is left.
+ssl_renew_days: ""
+
+# Run after every successful renewal. Services are reloaded via systemctl; the
+# command is appended verbatim for anything else (copying the cert, poking an API).
+ssl_reload_services: []
+ssl_deploy_hook_command: ""
+
+# Required inputs - no sensible default, set them when calling the role:
+#   ssl_domains          list of names, apex first, e.g. [example.com, "*.example.com"]
+#   ssl_cloudflare_token token scoped to Zone:DNS:Edit + Zone:Read (vault it)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,9 +4,24 @@ dependencies: []
 galaxy_info:
   role_name: ssl
   author: dsegurag
-  description: An Ansible role for generating SSL certificates using Let's Encrypt, with DNS verification managed via Cloudflare.
+  description: >-
+    Install and configure certbot to issue and unattendedly renew Let's Encrypt
+    certificates, solving the DNS-01 challenge via Cloudflare.
   license: MIT
-  min_ansible_version: 2.17.4
+  min_ansible_version: "2.18"
   platforms:
     - name: Debian
+      versions:
+        - bookworm
+        - trixie
     - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - tls
+    - certificate
+    - letsencrypt
+    - acme
+    - certbot
+    - cloudflare

--- a/requirements-ansible.txt
+++ b/requirements-ansible.txt
@@ -1,2 +1,2 @@
-ansible==14.3.1
+ansible-core==2.21.3
 ansible-lint==26.8.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,114 +1,111 @@
 ---
-- name: ssl certificate
-  block:
-    - name: ensure "ssl_cloudflare_domain" variable is provided
-      ansible.builtin.assert:
-        that:
-          - ssl_cloudflare_domain is defined
-          - ssl_cloudflare_domain != ''
-        fail_msg: "The ssl_cloudflare_domain variable is mandatory."
+# Install and configure certbot so the instance issues its own TLS certificate
+# from an ACME CA - Let's Encrypt by default - and renews it unattended through
+# certbot's own systemd timer, solving the DNS-01 challenge via Cloudflare.
+# Because the challenge is solved over DNS, one certificate can cover the apex
+# and every subdomain (*.example.com).
 
-    - name: ensure "ssl_cloudflare_token" variable is provided
-      ansible.builtin.assert:
-        that:
-          - ssl_cloudflare_token is defined
-          - ssl_cloudflare_token != ''
-        fail_msg: "The ssl_cloudflare_token variable is mandatory."
+- name: Ensure the required variables are provided
+  ansible.builtin.assert:
+    that:
+      - ssl_domains is defined
+      - ssl_domains is sequence
+      - ssl_domains is not string
+      - ssl_domains | length > 0
+      - ssl_cloudflare_token is defined
+      - ssl_cloudflare_token | length > 0
+    fail_msg: >-
+      ssl_domains (a non-empty list of domain names, apex first) and
+      ssl_cloudflare_token are mandatory.
 
-    - name: check if the certifiacte directory exists
-      ansible.builtin.stat:
-        path: "{{ ssl_cert_directory }}"
-      register: cert_directory
+- name: Install certbot and the Cloudflare DNS plugin
+  ansible.builtin.apt:
+    name:
+      - certbot
+      - python3-certbot-dns-cloudflare
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
 
-    - name: create the certifiacte directory if it does not exist
-      ansible.builtin.file:
-        path: "{{ ssl_cert_directory }}"
-        state: directory
-        mode: "755"
-      when: not cert_directory.stat.exists
+# The token stays in this file rather than on certbot's command line, so it is
+# never visible in the process list.
+- name: Write the Cloudflare credentials file
+  ansible.builtin.template:
+    src: cloudflare.ini.j2
+    dest: "{{ ssl_credentials_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  no_log: true
 
-    - name: check if the key directory exists
-      ansible.builtin.stat:
-        path: "{{ ssl_key_directory }}"
-      register: key_directory
+# The certbot package ships cli.ini and the systemd units but not the hook
+# directories - certbot creates them on first run, which is after this task.
+- name: Create the deploy hook directory
+  ansible.builtin.file:
+    path: /etc/letsencrypt/renewal-hooks/deploy
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ssl_reload_services | length > 0 or ssl_deploy_hook_command | length > 0
 
-    - name: create the key directory if it does not exist
-      ansible.builtin.file:
-        path: "{{ ssl_key_directory }}"
-        state: directory
-        mode: "700"
-      when: not key_directory.stat.exists
+# Dropping the hook in renewal-hooks/deploy/ instead of passing --deploy-hook
+# keeps it declarative: changing it is a file rewrite, not a certificate
+# reissue. The script guards on $RENEWED_LINEAGE so it stays quiet when certbot
+# renews some other certificate on the same host.
+- name: Install the deploy hook
+  ansible.builtin.template:
+    src: deploy-hook.sh.j2
+    dest: "/etc/letsencrypt/renewal-hooks/deploy/{{ ssl_cert_name }}.sh"
+    owner: root
+    group: root
+    mode: "0755"
+  when: ssl_reload_services | length > 0 or ssl_deploy_hook_command | length > 0
 
-    - name: create private key (rsa, 4096 bits)
-      register: private_key
-      community.crypto.openssl_privatekey:
-        path: "{{ ssl_key_directory }}/{{ ssl_cloudflare_domain }}.key"
+# --keep-until-expiring makes this a no-op while the certificate covers the same
+# domains and is not due for renewal, so the task can run unconditionally. That
+# is deliberate: a "creates:" guard would silently ignore changes to ssl_domains.
+- name: Issue the certificate
+  ansible.builtin.command:
+    cmd: >-
+      certbot certonly
+      --non-interactive
+      --agree-tos
+      --email {{ ssl_email | quote }}
+      --server {{ ssl_acme_directory | quote }}
+      --cert-name {{ ssl_cert_name | quote }}
+      {{ ssl_domains | map('regex_replace', '^', '-d ') | join(' ') }}
+      --dns-cloudflare
+      --dns-cloudflare-credentials {{ ssl_credentials_file | quote }}
+      --dns-cloudflare-propagation-seconds {{ ssl_dns_propagation_seconds }}
+      --key-type {{ ssl_key_type | quote }}
+      {% if ssl_key_type == 'rsa' %}--rsa-key-size {{ ssl_rsa_key_size }}{% endif %}
+      --keep-until-expiring
+  register: ssl_certonly
+  changed_when: >-
+    'not yet due for renewal' not in ssl_certonly.stdout
+    and 'Keeping the existing certificate' not in ssl_certonly.stdout
 
-    - name: create certificate signing request (csr)
-      register: csr
-      community.crypto.openssl_csr:
-        path: "{{ ssl_cert_directory }}/{{ ssl_cloudflare_domain }}.csr"
-        privatekey_path: "{{ private_key.filename }}"
-        common_name: "{{ ssl_cloudflare_domain }}"
-        subject_alt_name: "{{ ssl_san_certificates }}"
+# renew_before_expiry in the renewal config is the version-portable way to move
+# the renewal window; the --renew-before-expiry flag is not in every certbot we
+# support (bookworm ships 2.0.0).
+- name: Set the renewal window
+  ansible.builtin.lineinfile:
+    path: "/etc/letsencrypt/renewal/{{ ssl_cert_name }}.conf"
+    regexp: '^renew_before_expiry\s*='
+    line: "renew_before_expiry = {{ ssl_renew_days }} days"
+    insertbefore: BOF
+    owner: root
+    group: root
+    mode: "0644"
+  when: ssl_renew_days | string | length > 0
 
-    - name: create private key (rsa, 4096 bits) for let's encrypt
-      register: letsencrypt_private_key
-      community.crypto.openssl_privatekey:
-        path: "{{ ssl_key_directory }}/{{ ssl_cloudflare_domain }}-letsencrypt.key"
-
-    - name: create a challenge for domain using a account key file
-      register: domain_challenge
-      community.crypto.acme_certificate:
-        account_email: "info@{{ ssl_cloudflare_domain }}"
-        account_key_src: "{{ letsencrypt_private_key.filename }}"
-        acme_version: 2
-        acme_directory: https://acme-v02.api.letsencrypt.org/directory
-        terms_agreed: true
-        challenge: dns-01
-        csr: "{{ csr.filename }}"
-        cert: "{{ ssl_cert_directory }}/{{ ssl_cloudflare_domain }}.crt"
-        remaining_days: 30
-
-    - name: create dns record for domain dns-01 challenge
-      when: domain_challenge['challenge_data'] is defined
-      with_dict: "{{ domain_challenge['challenge_data'] | default({}) }}"
-      community.general.cloudflare_dns:
-        api_token: "{{ ssl_cloudflare_token }}"
-        state: present
-        zone: "{{ ssl_cloudflare_domain }}"
-        type: TXT
-        solo: true
-        record: "{{ item.value['dns-01']['record'] }}"
-        value: "{{ item.value['dns-01']['resource_value'] }}"
-
-    - name: let the challenge be validated and retrieve the cert and intermediate certificate # noqa: no-handler
-      when: domain_challenge is changed
-      register: letsencrypt_validation
-      until: letsencrypt_validation is success
-      retries: 12
-      delay: 10
-      community.crypto.acme_certificate:
-        account_email: "{{ ssl_letsencrypt_email }}"
-        account_key_src: "{{ letsencrypt_private_key.filename }}"
-        acme_version: 2
-        acme_directory: https://acme-v02.api.letsencrypt.org/directory
-        challenge: dns-01
-        csr: "{{ csr.filename }}"
-        cert: "{{ ssl_cert_directory }}/{{ ssl_cloudflare_domain }}.crt"
-        fullchain: "{{ ssl_cert_directory }}/{{ ssl_cloudflare_domain }}-fullchain.crt"
-        chain: "{{ ssl_cert_directory }}/{{ ssl_cloudflare_domain }}-intermediate.crt"
-        data: "{{ domain_challenge }}"
-        remaining_days: 30
-
-  always:
-    - name: delete dns record for domain dns-01 challenge
-      when: domain_challenge['challenge_data'] is defined
-      with_dict: "{{ domain_challenge['challenge_data'] | default({}) }}"
-      community.general.cloudflare_dns:
-        api_token: "{{ ssl_cloudflare_token }}"
-        state: absent
-        zone: "{{ ssl_cloudflare_domain }}"
-        type: TXT
-        record: "{{ item.value['dns-01']['record'] }}"
-        value: "{{ item.value['dns-01']['resource_value'] }}"
+# The Debian package enables this already; asserting it catches a host where it
+# was stopped. The packaged /etc/cron.d/certbot is guarded on systemd being
+# absent, so there is no double renewal.
+- name: Enable unattended renewal
+  ansible.builtin.systemd_service:
+    name: certbot.timer
+    enabled: true
+    state: started
+  when: ssl_auto_renew

--- a/templates/cloudflare.ini.j2
+++ b/templates/cloudflare.ini.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+dns_cloudflare_api_token = {{ ssl_cloudflare_token }}

--- a/templates/deploy-hook.sh.j2
+++ b/templates/deploy-hook.sh.j2
@@ -1,0 +1,15 @@
+#!/bin/sh
+# {{ ansible_managed }}
+# Certbot runs every executable in this directory after a successful renewal, so
+# bail out unless the lineage that just renewed is ours.
+set -eu
+
+[ "${RENEWED_LINEAGE:-}" = "{{ ssl_dir }}" ] || exit 0
+{% if ssl_reload_services | length > 0 %}
+
+systemctl reload {{ ssl_reload_services | join(' ') }}
+{% endif %}
+{% if ssl_deploy_hook_command | length > 0 %}
+
+{{ ssl_deploy_hook_command }}
+{% endif %}


### PR DESCRIPTION
The role implemented the ACME protocol with community.crypto modules, so a certificate was only ever renewed when a playbook happened to run. It now installs and configures certbot, and renewal is handled on the host by certbot.timer without Ansible.

This removes the hand-rolled DNS-01 handling and with it four bugs that broke issuance: challenge TXT records published with solo: true (the apex and the wildcard share the _acme-challenge.<zone> record name, so the second value deleted the first), reading challenge_data instead of challenge_data_dns, no wait for DNS propagation before asking the CA to validate, and implicit ACME account handling using two different contact addresses for the same key.

BREAKING CHANGE: certificates are issued by certbot and written to /etc/letsencrypt/live/<ssl_cert_name>/. ssl_cloudflare_domain and ssl_san_certificates are replaced by ssl_domains, ssl_letsencrypt_email by ssl_email, and ssl_cert_directory/ssl_key_directory by ssl_dir. The Cloudflare token is now stored on the host at /etc/letsencrypt/cloudflare.ini. The default key type is ecdsa. Requires Debian or Ubuntu with systemd, and ansible-core 2.18 or higher.